### PR TITLE
fix(user/staff): Staff no puede cambiar su propio estado de is_staff

### DIFF
--- a/app/tests/user/test_user_staff.py
+++ b/app/tests/user/test_user_staff.py
@@ -66,3 +66,12 @@ class TestUserStaff(TestCase):
         })
         request = self.apiclient.put('/api/v1/user/staff/', data, content_type='application/json')
         self.assertEqual(request.status_code, 400)
+    
+    def test_make_user_staff_own_staff(self):
+        data = json.dumps({
+            'is_staff': False,
+        })
+        request = self.apiclient.put(self.url + str(self.staff_user.id), data, content_type='application/json')
+        self.assertEqual(request.status_code, 403)
+        self.staff_user.refresh_from_db()
+        self.assertTrue(self.staff_user.is_staff)

--- a/app/user/views.py
+++ b/app/user/views.py
@@ -128,6 +128,8 @@ class UserModelViewSet(ModelViewSet):
     if not 'is_staff' in request.data:
       return Response({'error': 'is_staff field is required'}, status=status.HTTP_400_BAD_REQUEST)
     user_id = request.query_params.get('id')
+    if str(user.id) == user_id:
+      return Response({'error': 'You cannot change your own staff status'}, status=status.HTTP_403_FORBIDDEN)
     try:
       user = User.objects.get(id=user_id)
       new_staff = request.data.get('is_staff') 


### PR DESCRIPTION
<!-- markdownlint-disable -->
## 🖼️ Contexto
<!-- markdownlint-enable -->

Cambie el endpoint user/staff, para que el usuario loggeado no pueda cambiar su estado de staff

 <!-- Acá damos el contexto necesario para entender los cambios realizados.
 Piensa que esto lo va a leer alguien que no sabe nada
 respecto a estos cambios. -->

## 🛠️ Cambios realizados
<!-- > Acá va un punteo de los cambios que van incluidos en este PR, incluyendo
adiciones, sustracciones, reorganizaciones de archivos, etc. -->

Se actualizo el endpoint api/v1/user/staff/ y sus respectivos tests

## 🔚📍 Endpoints modificados
<!-- Opcional. Si los cambios incluyen la creación/modificación/eliminación de
endpoints, indícalos acá. -->

- api/v1/user/staff/


## ✅ Checklist
<!-- > Acá hay una lista de requisitos obligatorios que debes cumplir al momento de mergear tu PR. -->
- [x] Lo probé localmente.
- [x] Actualicé test antiguos.
- [x] Cree nuevos tests.
- [ ] Actualicé la API interna en Postman.
- [ ] Actualicé la API pública en Postman.
- [x] Revisé que las migraciones no conflictuen.

## 🧐 ¿Cómo se ve o cómo se prueba?
<!-- Opcional. Acá hacemos una mini demo de la nueva feature o bien explicamos
como probarla. Si son solo cambios de backend, puede servir un pantallazo de
postman llamando al endpoint afectado. -->

## ⏳ Pendientes

<!-- Otros puntos necesarios para completar la feature relacionada a los cambios
de este PR. Por ejemplo, cambios en otro proyecto, o alguna configuración de
deployment. También se pueden proponer mejoras futuras relacionadas a
estos cambios. -->

<!-- Usar la siguiente sintaxis: -->
<!-- - [ ] .. -->
